### PR TITLE
Add docs and themes

### DIFF
--- a/LLM_OVERVIEW.md
+++ b/LLM_OVERVIEW.md
@@ -1,0 +1,16 @@
+# Project Overview
+
+This monorepo provides a set of reusable React Native components alongside a demo Expo application. It uses **Bun** for package management and **react-native-unistyles** for theming. The UI pieces live in `packages/ui` and can be copied directly into any project.
+
+The goal is to offer a lightweight design system with customizable themes. The `unistyles.ts` file exposes a `createBase` helper which defines fonts, spacing and border radii. Each theme extends this base so radii can be overridden per theme. Color palettes for variants like `light`, `dark`, `chatgpt`, `vercel`, `unititled` and `cozy` showcase how to build different appearances.
+
+The demo application under `apps/demo` shows how the primitives fit together. Running it with Expo lets you preview all components on Android, iOS or web. The root `index.ts` file is simply a Bun entry point used to confirm that the environment is configured.
+
+Every UI element comes with a small markdown file under `packages/ui/ui/*.md` describing its purpose and prop interface. This approach allows you to copy what you need à la shadcn/ui, while keeping documentation close to the source. Because the library isn't published to npm, you are free to adapt the components as you see fit.
+
+- **packages/ui** – source of the UI library
+- **apps/demo** – Expo project showcasing the components
+- **index.ts** – minimal Bun entry point
+
+The project is written in TypeScript and follows a functional component approach. Each component exposes its prop types which are documented in the corresponding markdown files under `packages/ui/ui`.
+

--- a/README.md
+++ b/README.md
@@ -1,15 +1,69 @@
-# leshi
+# Leshi UI Monorepo
 
-To install dependencies:
+This repository contains a React Native component library (`packages/ui`) and an Expo demo application (`apps/demo`).
+
+## Requirements
+
+- [Bun](https://bun.sh/) runtime
+- Node.js 18 or newer
+- Yarn or npm (only for Expo CLI if desired)
+- Expo CLI (`npm install -g expo-cli`)
+
+## Installing dependencies
+
+Install all workspace packages using **Bun**:
 
 ```bash
 bun install
 ```
 
-To run:
+This command installs dependencies for the root package, the UI library and the demo app.
 
-```bash
-bun run index.ts
+## Running the demo application
+
+1. Navigate to the demo directory:
+
+   ```bash
+   cd apps/demo
+   ```
+
+2. Start the Expo development server:
+
+   ```bash
+   bun run start
+   ```
+
+   You can also run `bun run android`, `bun run ios` or `bun run web` to target specific platforms.
+
+## Using the UI package
+
+All components live under `packages/ui`. This project isn't published to npm. Instead, copy the pieces you need into your own codebase—similar to the [shadcn/ui](https://ui.shadcn.com/) approach.
+
+```tsx
+// after copying a component
+import { Button, Text } from './path-to-copied-components';
 ```
 
-This project was created using `bun init` in bun v1.1.33. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.
+The theme configuration is handled by `react-native-unistyles`. Edit `packages/ui/theme/unistyles.ts` to customise colors or add new themes. You can also override border radii per theme using the `createBase()` helper.
+
+## Project structure
+
+```
+leshi-ui/
+├─ apps/            # Example applications
+│  └─ demo/         # Expo demo showcasing the components
+├─ packages/
+│  └─ ui/           # Reusable UI library
+├─ index.ts         # Simple Bun entry point
+└─ bun.lockb        # Bun lockfile
+```
+
+## Development scripts
+
+- `bun install` – install dependencies
+- `bun run index.ts` – run the root script
+- Inside `apps/demo` you can run Expo scripts like `bun run start`
+
+---
+
+This project was bootstrapped with **Bun** v1.1.33.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,7 @@
+# Roadmap
+
+1. **Polish component APIs** – review props and add missing variants
+2. **Improve documentation** – add examples and usage guides
+3. **Automated testing** – set up unit and snapshot tests
+4. **CI/CD** – automate lint, build and release flows
+

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,15 +1,17 @@
-# ui
+# @leshi/ui
 
-To install dependencies:
+Reusable React Native component library powered by `react-native-unistyles`.
 
-```bash
-bun install
+## Installation
+
+This package isn't published to npm. Copy the components you need from this directory into your project.
+
+## Usage
+
+Import the components you copied and wrap your app with the `Unistyles` provider if needed.
+
+```tsx
+import { Button, Text } from './path-to-copied-components';
 ```
 
-To run:
-
-```bash
-bun run index.ts
-```
-
-This project was created using `bun init` in bun v1.1.33. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.
+Refer to the individual component documentation in `packages/ui/ui/*.md` for prop details.

--- a/packages/ui/theme/unistyles.ts
+++ b/packages/ui/theme/unistyles.ts
@@ -1,7 +1,16 @@
 import { StyleSheet } from "react-native-unistyles";
-const base = {
+
+const createBase = (
+  radii: { sm: number; md: number; lg: number; full: number; default: number } = {
+    sm: 4,
+    md: 6,
+    lg: 8,
+    full: 9999,
+    default: 10,
+  }
+) => ({
   gap: (n: number) => n * 4,
-  radii: { sm: 4, md: 6, lg: 8, full: 9999, default: 10 },
+  radii,
   /* theme.ts – solo la parte fonts */
   fonts: {
     family: {
@@ -23,9 +32,9 @@ const base = {
       "3xl": 28,
     },
   },
-};
+});
 const light = {
-  ...base,
+  ...createBase(),
   colors: {
     background: "#ffffff",
     foreground: "#171717",
@@ -53,7 +62,7 @@ const light = {
 };
 
 const dark = {
-  ...base,
+  ...createBase(),
   colors: {
     background: "#171717",
     foreground: "#fafafa",
@@ -80,7 +89,119 @@ const dark = {
   },
 };
 
-export const themes = { light, dark } as const;
+const chatgpt = {
+  ...createBase(),
+  colors: {
+    background: "#343541",
+    foreground: "#ececf1",
+    card: "#444654",
+    cardForeground: "#ececf1",
+    popover: "#444654",
+    popoverForeground: "#ececf1",
+    primary: "#10a37f",
+    onPrimary: "#ffffff",
+    secondary: "#202123",
+    onSecondary: "#ececf1",
+    muted: "#3e3f4b",
+    onMuted: "#a1a1aa",
+    accent: "#10a37f",
+    onAccent: "#ffffff",
+    destructive: "#e7000b",
+    onDestructive: "#ffffff",
+    border: "#3e3f4b",
+    input: "#3e3f4b",
+    ring: "#10a37f",
+    link: "#10a37f",
+    disabledBg: "#202123",
+    disabledText: "#52525b",
+  },
+};
+
+const vercel = {
+  ...createBase(),
+  colors: {
+    background: "#000000",
+    foreground: "#ffffff",
+    card: "#111111",
+    cardForeground: "#ffffff",
+    popover: "#111111",
+    popoverForeground: "#ffffff",
+    primary: "#ffffff",
+    onPrimary: "#000000",
+    secondary: "#333333",
+    onSecondary: "#ffffff",
+    muted: "#333333",
+    onMuted: "#dddddd",
+    accent: "#646cff",
+    onAccent: "#ffffff",
+    destructive: "#ff5555",
+    onDestructive: "#000000",
+    border: "#222222",
+    input: "#222222",
+    ring: "#646cff",
+    link: "#646cff",
+    disabledBg: "#333333",
+    disabledText: "#888888",
+  },
+};
+
+const unititled = {
+  ...createBase(),
+  colors: {
+    background: "#f9fafb",
+    foreground: "#111827",
+    card: "#ffffff",
+    cardForeground: "#111827",
+    popover: "#ffffff",
+    popoverForeground: "#111827",
+    primary: "#2563eb",
+    onPrimary: "#ffffff",
+    secondary: "#e5e7eb",
+    onSecondary: "#111827",
+    muted: "#e5e7eb",
+    onMuted: "#6b7280",
+    accent: "#2563eb",
+    onAccent: "#ffffff",
+    destructive: "#dc2626",
+    onDestructive: "#ffffff",
+    border: "#d1d5db",
+    input: "#d1d5db",
+    ring: "#2563eb",
+    link: "#2563eb",
+    disabledBg: "#e5e7eb",
+    disabledText: "#9ca3af",
+  },
+};
+
+const cozy = {
+  ...createBase({ sm: 6, md: 10, lg: 14, full: 9999, default: 12 }),
+  colors: {
+    background: "#fdf6e3",
+    foreground: "#002b36",
+    card: "#fefbec",
+    cardForeground: "#002b36",
+    popover: "#fefbec",
+    popoverForeground: "#002b36",
+    primary: "#b58900",
+    onPrimary: "#fdf6e3",
+    secondary: "#eee8d5",
+    onSecondary: "#002b36",
+    muted: "#eee8d5",
+    onMuted: "#586e75",
+    accent: "#cb4b16",
+    onAccent: "#fdf6e3",
+    destructive: "#dc322f",
+    onDestructive: "#fdf6e3",
+    border: "#e1dbcd",
+    input: "#e1dbcd",
+    ring: "#b58900",
+    link: "#268bd2",
+    disabledBg: "#eee8d5",
+    disabledText: "#93a1a1",
+  },
+};
+
+export const themes = { light, dark, chatgpt, vercel, unititled, cozy } as const;
 export const breakpoints = {
   xs: 0,
   sm: 360,

--- a/packages/ui/ui/avatar.md
+++ b/packages/ui/ui/avatar.md
@@ -1,0 +1,13 @@
+# Avatar
+
+User avatar primitives.
+
+- `Avatar` container
+- `AvatarImage` for displaying an image
+- `AvatarFallback` used when the image fails
+
+## Interfaces
+- `AvatarProps`
+- `AvatarImageProps`
+- `AvatarFallbackProps`
+

--- a/packages/ui/ui/badge.md
+++ b/packages/ui/ui/badge.md
@@ -1,0 +1,12 @@
+# Badge
+
+Small label used for statuses or counts.
+
+## Interface: `BadgeProps`
+- `children: React.ReactNode`
+- `variant?: BadgeVariant` ("primary" | "secondary" | "destructive" | "outline")
+- `size?: BadgeSize` ("sm" | "md" | "lg")
+- `leftIcon?: React.ReactNode`
+- `rightIcon?: React.ReactNode`
+- `style?: StyleProp<ViewStyle>`
+

--- a/packages/ui/ui/button.md
+++ b/packages/ui/ui/button.md
@@ -1,0 +1,13 @@
+# Button
+
+Pressable button component.
+
+## Interface: `ButtonProps`
+- ‘text: string’ label shown inside the button
+- ‘icon?: React.ReactNode’ optional icon element
+- ‘loading?: boolean’ show spinner and disable when true
+- ‘disabled?: boolean’ disable interaction
+- ‘variant?: ButtonVariant’ visual style (`primary` | `secondary` | `destructive` | `outline` | `ghost` | `link`)
+- ‘size?: ButtonSize’ pre-defined paddings (`sm` | `md` | `lg`)
+- ‘fullWidth?: boolean’ stretch to fill container width
+

--- a/packages/ui/ui/checkbox.md
+++ b/packages/ui/ui/checkbox.md
@@ -1,0 +1,14 @@
+# Checkbox
+
+Boolean selection component.
+
+## Interface: `CheckboxProps`
+- `checked?: boolean`
+- `onCheckedChange?: (val: boolean) => void`
+- `size?: CheckboxSize` ("sm" | "md" | "lg")
+- `disabled?: boolean`
+- `label?: string | React.ReactNode`
+- `labelPos?: CheckboxLabelPos` ("left" | "right")
+- `indicator?: React.ReactNode`
+- `wrapperStyle?: StyleProp<ViewStyle>`
+

--- a/packages/ui/ui/input.md
+++ b/packages/ui/ui/input.md
@@ -1,0 +1,15 @@
+# Input
+
+Text field component with optional label and icons.
+
+## Interface: `InputProps`
+- `label?: string`
+- `error?: string`
+- `size?: InputSize` ("sm" | "md" | "lg")
+- `textSize?: InputTextSize` ("xs" | "sm" | "md" | "lg" | "xl")
+- `leftIcon?: React.ReactNode`
+- `rightIcon?: React.ReactNode`
+- `inputStyle?: StyleProp<TextStyle>`
+- `wrapperStyle?: StyleProp<ViewStyle>`
+- Other `TextInput` props are forwarded
+

--- a/packages/ui/ui/progress.md
+++ b/packages/ui/ui/progress.md
@@ -1,0 +1,9 @@
+# Progress
+
+Linear progress indicator.
+
+## Interface: `ProgressProps`
+- `value?: number` progress percentage 0-100
+- `size?: ProgressSize` ("sm" | "md" | "lg")
+- `trackStyle?: StyleProp<ViewStyle>`
+

--- a/packages/ui/ui/radio.md
+++ b/packages/ui/ui/radio.md
@@ -1,0 +1,21 @@
+# Radio
+
+Grouped radio button component.
+
+## Interface: `RadioGroupProps`
+- `value: string | null`
+- `onValueChange: (val: string) => void`
+- `size?: RadioSize` ("sm" | "md" | "lg")
+- `disabled?: boolean`
+- `direction?: "row" | "column"`
+- `gap?: number`
+- `style?: StyleProp<ViewStyle>`
+
+## Interface: `RadioGroupItemProps`
+- `value: string`
+- `label?: React.ReactNode`
+- `labelStyle?: StyleProp<TextStyle>`
+- `wrapperStyle?: StyleProp<ViewStyle>`
+- `indicator?: React.ReactNode`
+- `disabled?: boolean`
+

--- a/packages/ui/ui/surface.md
+++ b/packages/ui/ui/surface.md
@@ -1,0 +1,10 @@
+# Surface
+
+Container component with optional elevation.
+
+## Interface: `SurfaceProps`
+- `variant?: SurfaceVariant` ("flat" | "outline" | "elevated")
+- `align?: SurfaceAlign` ("start" | "center" | "end")
+- `style?: StyleProp<ViewStyle>`
+- `children?: React.ReactNode`
+

--- a/packages/ui/ui/switch.md
+++ b/packages/ui/ui/switch.md
@@ -1,0 +1,11 @@
+# Switch
+
+Toggle switch component.
+
+## Interface: `SwitchProps`
+- `value: boolean`
+- `onValueChange: (val: boolean) => void`
+- `size?: SwitchSize` ("sm" | "md" | "lg")
+- `disabled?: boolean`
+- Inherits `PressableProps`
+

--- a/packages/ui/ui/text-area.md
+++ b/packages/ui/ui/text-area.md
@@ -1,0 +1,15 @@
+# Textarea
+
+Multiline text input component.
+
+## Interface: `TextareaProps`
+- `label?: string`
+- `error?: string`
+- `size?: TextareaSize` ("sm" | "md" | "lg")
+- `textSize?: TextareaTextSize` ("xs" | "sm" | "md" | "lg" | "xl")
+- `leftIcon?: React.ReactNode`
+- `rightIcon?: React.ReactNode`
+- `inputStyle?: StyleProp<TextStyle>`
+- `wrapperStyle?: StyleProp<ViewStyle>`
+- Other `TextInput` props are forwarded
+

--- a/packages/ui/ui/text.md
+++ b/packages/ui/ui/text.md
@@ -1,0 +1,11 @@
+# Text
+
+Typography component for displaying text.
+
+## Interface: `TypoProps`
+- `size?: TextSize` ("xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl")
+- `weight?: TextWeight` ("regular" | "medium" | "semibold" | "bold")
+- `tone?: TextTone` ("muted" | "primary" | "secondary" | "destructive" | "link" | "accent")
+- `align?: "auto" | "left" | "right" | "center" | "justify"`
+- `italic?: boolean`
+


### PR DESCRIPTION
## Summary
- update root README with installation guide
- document `@leshi/ui` package
- add multiple UI themes (chatgpt, vercel, unititled, cozy)
- create per component docs
- add project roadmap and overview

## Testing
- `bun run index.ts`
- `bun run start` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684873d4635483208da5a428fe082d0a