### PR TITLE
Update dialog components with modal props

### DIFF
--- a/packages/rn/ui/alert-dialog.tsx
+++ b/packages/rn/ui/alert-dialog.tsx
@@ -16,7 +16,7 @@ import {
   type ViewStyle,
   type TextStyle,
 } from "react-native";
-import { Modal } from "./modal";
+import { Modal, type ModalProps } from "./modal";
 import { useTheme } from "../theme/native";
 import { Text, type TextProps } from "./text";
 import { Button, type ButtonProps } from "./button";
@@ -92,31 +92,15 @@ function Trigger({ children, onPress, asChild, ...rest }: TriggerProps) {
   );
 }
 
-/*──────── Overlay */
-interface OverlayProps extends ViewProps {
-  style?: StyleProp<ViewStyle>;
-}
-function Overlay({ style, ...rest }: OverlayProps) {
-  const s = useStyles();
-  return <View style={[s.overlay, style]} {...rest} />;
-}
-
-/*──────── Center wrapper */
-function Center({ style, ...rest }: ViewProps) {
-  const s = useStyles();
-  return <View style={[s.center, style]} {...rest} />;
-}
-
 /*──────── Content = Modal + card */
-interface ContentProps extends ViewProps {
-  overlayStyle?: StyleProp<ViewStyle>;
+interface ContentProps extends ViewProps, ModalProps {
   centerStyle?: StyleProp<ViewStyle>;
 }
 function Content({
   children,
   style,
-  overlayStyle,
   centerStyle,
+  statusBarTranslucent = true,
   ...rest
 }: ContentProps) {
   const { open, setOpen } = useDialog();
@@ -127,16 +111,17 @@ function Content({
   return (
     <Modal
       transparent
-      statusBarTranslucent
       visible
       onRequestClose={() => setOpen(false)}
       animationType="fade"
+      statusBarTranslucent={statusBarTranslucent}
+      {...rest}
     >
-      <Center style={centerStyle}>
-        <View style={[s.card, style]} {...rest}>
+      <View style={[s.center, centerStyle]}>
+        <View style={[s.card, style]}>
           {children}
         </View>
-      </Center>
+      </View>
     </Modal>
   );
 }
@@ -220,10 +205,6 @@ function useStyles() {
   return useMemo(
     () =>
       StyleSheet.create({
-        overlay: {
-          ...StyleSheet.absoluteFillObject,
-          backgroundColor: "rgba(0,0,0,0.5)",
-        },
         center: {
           flex: 1,
           justifyContent: "center",
@@ -260,7 +241,6 @@ export const AlertDialog = {
   Content,
   Header,
   Footer,
-  Overlay,
   Title,
   Description,
   Action,

--- a/packages/rn/ui/dialog.tsx
+++ b/packages/rn/ui/dialog.tsx
@@ -16,7 +16,7 @@ import {
   type ViewStyle,
   type TextStyle,
 } from "react-native";
-import { Modal } from "./modal";
+import { Modal, type ModalProps } from "./modal";
 import { useTheme } from "../theme/native";
 import { Text, type TextProps } from "./text";
 import { Pressable as SlotPressable } from "./slot";
@@ -86,21 +86,6 @@ function Trigger({ children, onPress, asChild, ...rest }: TriggerProps) {
   );
 }
 
-/*──────────────────── Overlay */
-interface OverlayProps extends ViewProps {
-  style?: StyleProp<ViewStyle>;
-}
-function Overlay({ style, ...rest }: OverlayProps) {
-  const s = useStyles();
-  return <View style={[s.overlay, style]} {...rest} />;
-}
-
-/*──────────────────── Center wrapper */
-function Center({ style, ...rest }: ViewProps) {
-  const s = useStyles();
-  return <View style={[s.center, style]} {...rest} />;
-}
-
 /*──────────────────── Close */
 interface CloseProps extends PressableProps {
   children: React.ReactNode;
@@ -137,17 +122,16 @@ function Close({ children, onPress, asChild, ...rest }: CloseProps) {
 }
 
 /*──────────────────── Content (Modal + card) */
-interface ContentProps extends ViewProps {
-  overlayStyle?: StyleProp<ViewStyle>;
+interface ContentProps extends ViewProps, ModalProps {
   centerStyle?: StyleProp<ViewStyle>;
   showCloseButton?: boolean;
 }
 function Content({
   children,
   style,
-  overlayStyle,
   centerStyle,
   showCloseButton = true,
+  statusBarTranslucent = true,
   ...rest
 }: ContentProps) {
   const { open, setOpen } = useDialog();
@@ -158,13 +142,14 @@ function Content({
   return (
     <Modal
       transparent
-      statusBarTranslucent
       visible
       onRequestClose={() => setOpen(false)}
       animationType="fade"
+      statusBarTranslucent={statusBarTranslucent}
+      {...rest}
     >
-      <Center style={centerStyle}>
-        <View style={[s.card, style]} {...rest}>
+      <View style={[s.center, centerStyle]}>
+        <View style={[s.card, style]}>
           {children}
           {showCloseButton && (
             <Close
@@ -176,7 +161,7 @@ function Content({
             </Close>
           )}
         </View>
-      </Center>
+      </View>
     </Modal>
   );
 }
@@ -231,10 +216,6 @@ function useStyles() {
   return useMemo(
     () =>
       StyleSheet.create({
-        overlay: {
-          ...StyleSheet.absoluteFillObject,
-          backgroundColor: "rgba(0,0,0,0.5)",
-        },
         center: {
           flex: 1,
           justifyContent: "center",
@@ -276,7 +257,6 @@ export const Dialog = {
   Root,
   Trigger,
   Content,
-  Overlay,
   Header,
   Footer,
   Title,

--- a/packages/rn/ui/modal.tsx
+++ b/packages/rn/ui/modal.tsx
@@ -1,8 +1,11 @@
 import React from "react";
-import RNModal, { type ModalProps as RNModalModalProps } from "react-native-modal";
+import RNModal, {
+  type ModalProps as RNModalModalProps,
+} from "react-native-modal";
 import type { ModalProps as BaseModalProps } from "react-native";
 
-export type ModalProps = BaseModalProps;
+export type ModalProps = BaseModalProps &
+  Omit<RNModalModalProps, "isVisible" | "children">;
 
 export const Modal: React.FC<ModalProps> = ({
   visible,

--- a/packages/unistiyles/ui/alert-dialog.tsx
+++ b/packages/unistiyles/ui/alert-dialog.tsx
@@ -15,7 +15,7 @@ import {
   type ViewStyle,
   type TextStyle,
 } from "react-native";
-import { Modal } from "./modal";
+import { Modal, type ModalProps } from "./modal";
 import { StyleSheet } from "react-native-unistyles";
 import { Button, type ButtonProps } from "./button";
 import { Text, type TextProps } from "./text";
@@ -90,29 +90,17 @@ function Trigger({ children, onPress, asChild, ...rest }: TriggerProps) {
   );
 }
 
-/*──────── Overlay */
-interface OverlayProps extends ViewProps {
-  style?: StyleProp<ViewStyle>;
-}
-function Overlay({ style, ...rest }: OverlayProps) {
-  return <View style={[styles.overlay, style]} {...rest} />;
-}
-
-/*──────── Center wrapper */
-function Center({ style, ...rest }: ViewProps) {
-  return <View style={[styles.center, style]} {...rest} />;
-}
+/*──────── Center style wrapper */
 
 /*──────── Content (Modal + card) */
-interface ContentProps extends ViewProps {
-  overlayStyle?: StyleProp<ViewStyle>;
+interface ContentProps extends ViewProps, ModalProps {
   centerStyle?: StyleProp<ViewStyle>;
 }
 function Content({
   children,
   style,
-  overlayStyle,
   centerStyle,
+  statusBarTranslucent = true,
   ...rest
 }: ContentProps) {
   const { open, setOpen } = useDialog();
@@ -122,16 +110,17 @@ function Content({
   return (
     <Modal
       transparent
-      statusBarTranslucent
       visible
       onRequestClose={() => setOpen(false)}
       animationType="fade"
+      statusBarTranslucent={statusBarTranslucent}
+      {...rest}
     >
-      <Center style={centerStyle}>
-        <View style={[styles.card, style]} {...rest}>
+      <View style={[styles.center, centerStyle]}>
+        <View style={[styles.card, style]}>
           {children}
         </View>
-      </Center>
+      </View>
     </Modal>
   );
 }
@@ -215,10 +204,6 @@ function Cancel({ text = "Cancel", variant, onPress, ...btn }: CTAProps) {
 
 /*──────── Styles (Unistyles) */
 const styles = StyleSheet.create((t) => ({
-  overlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(0,0,0,0.5)",
-  },
   center: {
     flex: 1,
     justifyContent: "center",
@@ -253,7 +238,6 @@ export const AlertDialog = {
   Content,
   Header,
   Footer,
-  Overlay,
   Title,
   Description,
   Action,

--- a/packages/unistiyles/ui/dialog.tsx
+++ b/packages/unistiyles/ui/dialog.tsx
@@ -15,7 +15,7 @@ import {
   type ViewStyle,
   type TextStyle,
 } from "react-native";
-import { Modal } from "./modal";
+import { Modal, type ModalProps } from "./modal";
 import { StyleSheet } from "react-native-unistyles";
 import { Text, type TextProps } from "./text";
 import { Icon } from "./icon";
@@ -95,31 +95,17 @@ function Trigger({ children, onPress, asChild, ...rest }: TriggerProps) {
   );
 }
 
-/*──────── Overlay */
-interface OverlayProps extends ViewProps {
-  style?: StyleProp<ViewStyle>;
-}
-function Overlay({ style, ...r }: OverlayProps) {
-  return <View style={[styles.overlay, style]} {...r} />;
-}
-
-/*──────── Center */
-function Center({ style, ...r }: ViewProps) {
-  return <View style={[styles.center, style]} {...r} />;
-}
-
 /*──────── Content */
-interface ContentProps extends ViewProps {
-  overlayStyle?: StyleProp<ViewStyle>;
+interface ContentProps extends ViewProps, ModalProps {
   centerStyle?: StyleProp<ViewStyle>;
   showCloseButton?: boolean;
 }
 function Content({
   children,
   style,
-  overlayStyle,
   centerStyle,
   showCloseButton = true,
+  statusBarTranslucent = true,
   ...rest
 }: ContentProps) {
   const { open, setOpen } = useDialog();
@@ -129,13 +115,14 @@ function Content({
   return (
     <Modal
       transparent
-      statusBarTranslucent
       visible
       onRequestClose={() => setOpen(false)}
       animationType="fade"
+      statusBarTranslucent={statusBarTranslucent}
+      {...rest}
     >
-      <Center style={centerStyle}>
-        <View style={[styles.card, style]} {...rest}>
+      <View style={[styles.center, centerStyle]}>
+        <View style={[styles.card, style]}>
           {children}
           {showCloseButton && (
             <Close
@@ -147,7 +134,7 @@ function Content({
             </Close>
           )}
         </View>
-      </Center>
+      </View>
     </Modal>
   );
 }
@@ -229,10 +216,6 @@ const Description: React.FC<DescriptionProps> = ({
 
 /*──────── styles */
 const styles = StyleSheet.create((t) => ({
-  overlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(0,0,0,0.5)",
-  },
   center: {
     flex: 1,
     justifyContent: "center",
@@ -271,7 +254,6 @@ export const Dialog = {
   Root,
   Trigger,
   Content,
-  Overlay,
   Header,
   Footer,
   Title,

--- a/packages/unistiyles/ui/modal.tsx
+++ b/packages/unistiyles/ui/modal.tsx
@@ -1,8 +1,11 @@
 import React from "react";
-import RNModal, { type ModalProps as RNModalModalProps } from "react-native-modal";
+import RNModal, {
+  type ModalProps as RNModalModalProps,
+} from "react-native-modal";
 import type { ModalProps as BaseModalProps } from "react-native";
 
-export type ModalProps = BaseModalProps;
+export type ModalProps = BaseModalProps &
+  Omit<RNModalModalProps, "isVisible" | "children">;
 
 export const Modal: React.FC<ModalProps> = ({
   visible,


### PR DESCRIPTION
## Summary
- extend `ModalProps` to include `react-native-modal` props
- pass modal props through `Dialog` and `AlertDialog`
- remove redundant overlay components and center wrappers
- align dialog styling with other components

## Testing
- `npx tsc -p packages/unistiyles/tsconfig.json`
- `npx tsc -p packages/rn/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6859ce4a1fdc8320987ac094857ac03b