### PR TITLE
Add multiple color themes

### DIFF
--- a/packages/rn/theme/themes/bubblegum.ts
+++ b/packages/rn/theme/themes/bubblegum.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const bubblegumLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(328 100% 97.0588%)",
+    foreground: "hsl(326.2810 71.5976% 33.1373%)",
+    primary: "hsl(328.9286 94.9153% 46.2745%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(300 100.0000% 91.9608%)",
+    secondaryForeground: "hsl(326.2810 71.5976% 33.1373%)",
+    muted: "hsl(327.8571 100% 94.5098%)",
+    mutedForeground: "hsl(329.0476 50.0000% 50.5882%)",
+    accent: "hsl(327.0968 100% 87.8431%)",
+    destructive: "hsl(340.7843 62.4490% 51.9608%)",
+    destructiveForeground: "hsl(0 0% 100%)",
+    border: "hsl(326.7857 100.0000% 89.0196%)",
+    card: "hsl(322.5000 100.0000% 98.4314%)",
+    input: "hsl(300 100.0000% 91.9608%)",
+    inputSurface: "hsl(327.8571 100% 94.5098%)",
+  },
+};
+
+export const bubblegumDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(280.8000 58.1395% 8.4314%)",
+    foreground: "hsl(300 100% 85.0980%)",
+    primary: "hsl(306.4865 100% 70.9804%)",
+    primaryForeground: "hsl(300 65.5172% 5.6863%)",
+    secondary: "hsl(288.5106 42.3423% 21.7647%)",
+    secondaryForeground: "hsl(300 100% 85.0980%)",
+    muted: "hsl(279 44.4444% 17.6471%)",
+    mutedForeground: "hsl(300 52.8736% 65.8824%)",
+    accent: "hsl(297.0968 50.0000% 24.3137%)",
+    destructive: "hsl(338.2326 100.0000% 57.8431%)",
+    destructiveForeground: "hsl(0 0% 97.6471%)",
+    border: "hsl(281.4706 55.7377% 23.9216%)",
+    card: "hsl(280 45.2055% 14.3137%)",
+    input: "hsl(288.5106 42.3423% 21.7647%)",
+    inputSurface: "hsl(279 44.4444% 17.6471%)",
+  },
+};

--- a/packages/rn/theme/themes/grape.ts
+++ b/packages/rn/theme/themes/grape.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const grapeLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(260 23.0769% 97.4510%)",
+    foreground: "hsl(243.1579 13.6691% 27.2549%)",
+    primary: "hsl(260.4000 22.9358% 57.2549%)",
+    primaryForeground: "hsl(260 23.0769% 97.4510%)",
+    secondary: "hsl(258.9474 33.3333% 88.8235%)",
+    secondaryForeground: "hsl(243.1579 13.6691% 27.2549%)",
+    muted: "hsl(258.0000 15.1515% 87.0588%)",
+    mutedForeground: "hsl(247.5000 10.3448% 45.4902%)",
+    accent: "hsl(342.4615 56.5217% 77.4510%)",
+    destructive: "hsl(0 62.1891% 60.5882%)",
+    destructiveForeground: "hsl(260 23.0769% 97.4510%)",
+    border: "hsl(258.7500 17.3913% 81.9608%)",
+    card: "hsl(0 0% 100%)",
+    input: "hsl(260.0000 23.0769% 92.3529%)",
+    inputSurface: "hsl(258.9474 33.3333% 88.8235%)",
+  },
+};
+
+export const grapeDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(250.9091 18.6441% 11.5686%)",
+    foreground: "hsl(250.0000 36.0000% 90.1961%)",
+    primary: "hsl(263.0769 32.5000% 68.6275%)",
+    primaryForeground: "hsl(250.9091 18.6441% 11.5686%)",
+    secondary: "hsl(254.4828 14.8718% 38.2353%)",
+    secondaryForeground: "hsl(250.0000 36.0000% 90.1961%)",
+    muted: "hsl(254.1176 20.9877% 15.8824%)",
+    mutedForeground: "hsl(258.9474 10.3825% 64.1176%)",
+    accent: "hsl(271.7647 15.5963% 21.3725%)",
+    destructive: "hsl(0 68.6747% 67.4510%)",
+    destructiveForeground: "hsl(250.9091 18.6441% 11.5686%)",
+    border: "hsl(252 18.5185% 21.1765%)",
+    card: "hsl(251.2500 20% 15.6863%)",
+    input: "hsl(249.4737 19.5876% 19.0196%)",
+    inputSurface: "hsl(254.4828 14.8718% 38.2353%)",
+  },
+};

--- a/packages/rn/theme/themes/index.ts
+++ b/packages/rn/theme/themes/index.ts
@@ -1,8 +1,29 @@
 import { dark } from "./dark";
 import { light } from "./light";
+import { grapeLight, grapeDark } from "./grape";
+import { peachLight, peachDark } from "./peach";
+import { retroLight, retroDark } from "./retro";
+import { monoLight, monoDark } from "./mono";
+import { lavenderLight, lavenderDark } from "./lavender";
+import { oceanLight, oceanDark } from "./ocean";
+import { bubblegumLight, bubblegumDark } from "./bubblegum";
 
 export const themes = {
   light,
   dark,
+  grapeLight,
+  grapeDark,
+  peachLight,
+  peachDark,
+  retroLight,
+  retroDark,
+  monoLight,
+  monoDark,
+  lavenderLight,
+  lavenderDark,
+  oceanLight,
+  oceanDark,
+  bubblegumLight,
+  bubblegumDark,
 };
 export type ThemeName = keyof typeof themes;

--- a/packages/rn/theme/themes/lavender.ts
+++ b/packages/rn/theme/themes/lavender.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const lavenderLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(280.0000 33.3333% 96.4706%)",
+    foreground: "hsl(216.9231 19.1176% 26.6667%)",
+    primary: "hsl(255.1351 91.7355% 76.2745%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(267.5676 90.2439% 91.9608%)",
+    secondaryForeground: "hsl(215 13.7931% 34.1176%)",
+    muted: "hsl(268.6957 100.0000% 95.4902%)",
+    mutedForeground: "hsl(220 8.9362% 46.0784%)",
+    accent: "hsl(292.5000 44.4444% 92.9412%)",
+    destructive: "hsl(0 93.5484% 81.7647%)",
+    destructiveForeground: "hsl(0 0% 100%)",
+    border: "hsl(267.5676 90.2439% 91.9608%)",
+    card: "hsl(0 0% 100%)",
+    input: "hsl(267.5676 90.2439% 91.9608%)",
+    inputSurface: "hsl(267.5676 90.2439% 91.9608%)",
+  },
+};
+
+export const lavenderDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(24 9.8039% 10%)",
+    foreground: "hsl(226.4516 100% 93.9216%)",
+    primary: "hsl(255.9036 95.4023% 82.9412%)",
+    primaryForeground: "hsl(24 9.8039% 10%)",
+    secondary: "hsl(272.5000 19.3548% 24.3137%)",
+    secondaryForeground: "hsl(216.0000 12.1951% 83.9216%)",
+    muted: "hsl(270 17.7778% 17.6471%)",
+    mutedForeground: "hsl(217.8947 10.6145% 64.9020%)",
+    accent: "hsl(266.8966 19.2053% 29.6078%)",
+    destructive: "hsl(0 93.5484% 81.7647%)",
+    destructiveForeground: "hsl(24 9.8039% 10%)",
+    border: "hsl(272.5000 19.3548% 24.3137%)",
+    card: "hsl(270 17.7778% 17.6471%)",
+    input: "hsl(272.5000 19.3548% 24.3137%)",
+    inputSurface: "hsl(272.5000 19.3548% 24.3137%)",
+  },
+};

--- a/packages/rn/theme/themes/mono.ts
+++ b/packages/rn/theme/themes/mono.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const monoLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 100%)",
+    foreground: "hsl(0 0% 3.9216%)",
+    primary: "hsl(0 0% 45.0980%)",
+    primaryForeground: "hsl(0 0% 98.0392%)",
+    secondary: "hsl(0 0% 96.0784%)",
+    secondaryForeground: "hsl(0 0% 9.0196%)",
+    muted: "hsl(0 0% 96.0784%)",
+    mutedForeground: "hsl(0 0% 44.3137%)",
+    accent: "hsl(0 0% 96.0784%)",
+    destructive: "hsl(357.1429 100% 45.2941%)",
+    destructiveForeground: "hsl(0 0% 96.0784%)",
+    border: "hsl(0 0% 89.8039%)",
+    card: "hsl(0 0% 100%)",
+    input: "hsl(0 0% 89.8039%)",
+    inputSurface: "hsl(0 0% 96.0784%)",
+  },
+};
+
+export const monoDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 3.9216%)",
+    foreground: "hsl(0 0% 98.0392%)",
+    primary: "hsl(0 0% 45.0980%)",
+    primaryForeground: "hsl(0 0% 98.0392%)",
+    secondary: "hsl(0 0% 14.9020%)",
+    secondaryForeground: "hsl(0 0% 98.0392%)",
+    muted: "hsl(0 0% 14.9020%)",
+    mutedForeground: "hsl(0 0% 63.1373%)",
+    accent: "hsl(0 0% 25.0980%)",
+    destructive: "hsl(358.8387 100% 69.6078%)",
+    destructiveForeground: "hsl(0 0% 14.9020%)",
+    border: "hsl(0 0% 21.9608%)",
+    card: "hsl(0 0% 9.8039%)",
+    input: "hsl(0 0% 32.1569%)",
+    inputSurface: "hsl(0 0% 14.9020%)",
+  },
+};

--- a/packages/rn/theme/themes/ocean.ts
+++ b/packages/rn/theme/themes/ocean.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const oceanLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 100%)",
+    foreground: "hsl(210 25% 7.8431%)",
+    primary: "hsl(203.8863 88.2845% 53.1373%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(210 25% 7.8431%)",
+    secondaryForeground: "hsl(0 0% 100%)",
+    muted: "hsl(240 1.9608% 90%)",
+    mutedForeground: "hsl(210 25% 7.8431%)",
+    accent: "hsl(211.5789 51.3514% 92.7451%)",
+    destructive: "hsl(356.3033 90.5579% 54.3137%)",
+    destructiveForeground: "hsl(0 0% 100%)",
+    border: "hsl(201.4286 30.4348% 90.9804%)",
+    card: "hsl(180 6.6667% 97.0588%)",
+    input: "hsl(200 23.0769% 97.4510%)",
+    inputSurface: "hsl(240 1.9608% 90%)",
+  },
+};
+
+export const oceanDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 0%)",
+    foreground: "hsl(200 6.6667% 91.1765%)",
+    primary: "hsl(203.7736 87.6033% 52.5490%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(195.0000 15.3846% 94.9020%)",
+    secondaryForeground: "hsl(210 25% 7.8431%)",
+    muted: "hsl(0 0% 9.4118%)",
+    mutedForeground: "hsl(210 3.3898% 46.2745%)",
+    accent: "hsl(205.7143 70% 7.8431%)",
+    destructive: "hsl(356.3033 90.5579% 54.3137%)",
+    destructiveForeground: "hsl(0 0% 100%)",
+    border: "hsl(210 5.2632% 14.9020%)",
+    card: "hsl(228 9.8039% 10%)",
+    input: "hsl(207.6923 27.6596% 18.4314%)",
+    inputSurface: "hsl(0 0% 9.4118%)",
+  },
+};

--- a/packages/rn/theme/themes/peach.ts
+++ b/packages/rn/theme/themes/peach.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const peachLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(330 47.0588% 93.3333%)",
+    foreground: "hsl(0 0% 35.6863%)",
+    primary: "hsl(325.5814 57.8475% 56.2745%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(181.6901 43.5583% 68.0392%)",
+    secondaryForeground: "hsl(0 0% 20%)",
+    muted: "hsl(190.5263 58.7629% 80.9804%)",
+    mutedForeground: "hsl(0 0% 47.8431%)",
+    accent: "hsl(42.1429 91.3043% 81.9608%)",
+    destructive: "hsl(359.5652 92.0000% 70.5882%)",
+    destructiveForeground: "hsl(0 0% 100%)",
+    border: "hsl(325.5814 57.8475% 56.2745%)",
+    card: "hsl(41.5385 92.8571% 89.0196%)",
+    input: "hsl(0 0% 89.4118%)",
+    inputSurface: "hsl(181.6901 43.5583% 68.0392%)",
+  },
+};
+
+export const peachDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(201.4286 43.7500% 12.5490%)",
+    foreground: "hsl(333.7500 40.0000% 92.1569%)",
+    primary: "hsl(42.1429 91.3043% 81.9608%)",
+    primaryForeground: "hsl(201.4286 43.7500% 12.5490%)",
+    secondary: "hsl(346.3636 55.0000% 76.4706%)",
+    secondaryForeground: "hsl(201.4286 43.7500% 12.5490%)",
+    muted: "hsl(214.2857 8.8608% 15.4902%)",
+    mutedForeground: "hsl(346.3636 55.0000% 76.4706%)",
+    accent: "hsl(338.4000 39.6825% 62.9412%)",
+    destructive: "hsl(328.4211 70.3704% 62.9412%)",
+    destructiveForeground: "hsl(201.4286 43.7500% 12.5490%)",
+    border: "hsl(206.1538 28.0576% 27.2549%)",
+    card: "hsl(201.4286 33.3333% 16.4706%)",
+    input: "hsl(200.6897 31.1828% 18.2353%)",
+    inputSurface: "hsl(346.3636 55.0000% 76.4706%)",
+  },
+};

--- a/packages/rn/theme/themes/retro.ts
+++ b/packages/rn/theme/themes/retro.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const retroLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 80%)",
+    foreground: "hsl(0 0% 12.1569%)",
+    primary: "hsl(0 73.4597% 41.3725%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(82 38.9610% 30.1961%)",
+    secondaryForeground: "hsl(0 0% 100%)",
+    muted: "hsl(0 0% 72.1569%)",
+    mutedForeground: "hsl(0 0% 29.0196%)",
+    accent: "hsl(207.2727 44% 49.0196%)",
+    destructive: "hsl(26.1176 100% 50%)",
+    destructiveForeground: "hsl(0 0% 0%)",
+    border: "hsl(0 0% 31.3725%)",
+    card: "hsl(0 0% 69.0196%)",
+    input: "hsl(0 0% 31.3725%)",
+    inputSurface: "hsl(0 0% 72.1569%)",
+  },
+};
+
+export const retroDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 10.1961%)",
+    foreground: "hsl(0 0% 87.8431%)",
+    primary: "hsl(1.3636 77.1930% 55.2941%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(92.0388 47.9070% 42.1569%)",
+    secondaryForeground: "hsl(0 0% 0%)",
+    muted: "hsl(0 0% 14.5098%)",
+    mutedForeground: "hsl(0 0% 62.7451%)",
+    accent: "hsl(206.7123 89.0244% 67.8431%)",
+    destructive: "hsl(37.6471 100% 50%)",
+    destructiveForeground: "hsl(0 0% 0%)",
+    border: "hsl(0 0% 29.0196%)",
+    card: "hsl(0 0% 16.4706%)",
+    input: "hsl(0 0% 29.0196%)",
+    inputSurface: "hsl(0 0% 14.5098%)",
+  },
+};

--- a/packages/unistiyles/theme/themes/bubblegum.ts
+++ b/packages/unistiyles/theme/themes/bubblegum.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const bubblegumLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(328 100% 97.0588%)",
+    foreground: "hsl(326.2810 71.5976% 33.1373%)",
+    primary: "hsl(328.9286 94.9153% 46.2745%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(300 100.0000% 91.9608%)",
+    secondaryForeground: "hsl(326.2810 71.5976% 33.1373%)",
+    muted: "hsl(327.8571 100% 94.5098%)",
+    mutedForeground: "hsl(329.0476 50.0000% 50.5882%)",
+    accent: "hsl(327.0968 100% 87.8431%)",
+    destructive: "hsl(340.7843 62.4490% 51.9608%)",
+    destructiveForeground: "hsl(0 0% 100%)",
+    border: "hsl(326.7857 100.0000% 89.0196%)",
+    card: "hsl(322.5000 100.0000% 98.4314%)",
+    input: "hsl(300 100.0000% 91.9608%)",
+    inputSurface: "hsl(327.8571 100% 94.5098%)",
+  },
+};
+
+export const bubblegumDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(280.8000 58.1395% 8.4314%)",
+    foreground: "hsl(300 100% 85.0980%)",
+    primary: "hsl(306.4865 100% 70.9804%)",
+    primaryForeground: "hsl(300 65.5172% 5.6863%)",
+    secondary: "hsl(288.5106 42.3423% 21.7647%)",
+    secondaryForeground: "hsl(300 100% 85.0980%)",
+    muted: "hsl(279 44.4444% 17.6471%)",
+    mutedForeground: "hsl(300 52.8736% 65.8824%)",
+    accent: "hsl(297.0968 50.0000% 24.3137%)",
+    destructive: "hsl(338.2326 100.0000% 57.8431%)",
+    destructiveForeground: "hsl(0 0% 97.6471%)",
+    border: "hsl(281.4706 55.7377% 23.9216%)",
+    card: "hsl(280 45.2055% 14.3137%)",
+    input: "hsl(288.5106 42.3423% 21.7647%)",
+    inputSurface: "hsl(279 44.4444% 17.6471%)",
+  },
+};

--- a/packages/unistiyles/theme/themes/grape.ts
+++ b/packages/unistiyles/theme/themes/grape.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const grapeLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(260 23.0769% 97.4510%)",
+    foreground: "hsl(243.1579 13.6691% 27.2549%)",
+    primary: "hsl(260.4000 22.9358% 57.2549%)",
+    primaryForeground: "hsl(260 23.0769% 97.4510%)",
+    secondary: "hsl(258.9474 33.3333% 88.8235%)",
+    secondaryForeground: "hsl(243.1579 13.6691% 27.2549%)",
+    muted: "hsl(258.0000 15.1515% 87.0588%)",
+    mutedForeground: "hsl(247.5000 10.3448% 45.4902%)",
+    accent: "hsl(342.4615 56.5217% 77.4510%)",
+    destructive: "hsl(0 62.1891% 60.5882%)",
+    destructiveForeground: "hsl(260 23.0769% 97.4510%)",
+    border: "hsl(258.7500 17.3913% 81.9608%)",
+    card: "hsl(0 0% 100%)",
+    input: "hsl(260.0000 23.0769% 92.3529%)",
+    inputSurface: "hsl(258.9474 33.3333% 88.8235%)",
+  },
+};
+
+export const grapeDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(250.9091 18.6441% 11.5686%)",
+    foreground: "hsl(250.0000 36.0000% 90.1961%)",
+    primary: "hsl(263.0769 32.5000% 68.6275%)",
+    primaryForeground: "hsl(250.9091 18.6441% 11.5686%)",
+    secondary: "hsl(254.4828 14.8718% 38.2353%)",
+    secondaryForeground: "hsl(250.0000 36.0000% 90.1961%)",
+    muted: "hsl(254.1176 20.9877% 15.8824%)",
+    mutedForeground: "hsl(258.9474 10.3825% 64.1176%)",
+    accent: "hsl(271.7647 15.5963% 21.3725%)",
+    destructive: "hsl(0 68.6747% 67.4510%)",
+    destructiveForeground: "hsl(250.9091 18.6441% 11.5686%)",
+    border: "hsl(252 18.5185% 21.1765%)",
+    card: "hsl(251.2500 20% 15.6863%)",
+    input: "hsl(249.4737 19.5876% 19.0196%)",
+    inputSurface: "hsl(254.4828 14.8718% 38.2353%)",
+  },
+};

--- a/packages/unistiyles/theme/themes/index.ts
+++ b/packages/unistiyles/theme/themes/index.ts
@@ -1,7 +1,48 @@
 export { fonts, shadows, sizes, radii } from "./common";
 import { light } from "./light";
 import { dark } from "./dark";
-export { light, dark };
+import { grapeLight, grapeDark } from "./grape";
+import { peachLight, peachDark } from "./peach";
+import { retroLight, retroDark } from "./retro";
+import { monoLight, monoDark } from "./mono";
+import { lavenderLight, lavenderDark } from "./lavender";
+import { oceanLight, oceanDark } from "./ocean";
+import { bubblegumLight, bubblegumDark } from "./bubblegum";
+export {
+  light,
+  dark,
+  grapeLight,
+  grapeDark,
+  peachLight,
+  peachDark,
+  retroLight,
+  retroDark,
+  monoLight,
+  monoDark,
+  lavenderLight,
+  lavenderDark,
+  oceanLight,
+  oceanDark,
+  bubblegumLight,
+  bubblegumDark,
+};
 
-export const themes = { light, dark } as const;
+export const themes = {
+  light,
+  dark,
+  grapeLight,
+  grapeDark,
+  peachLight,
+  peachDark,
+  retroLight,
+  retroDark,
+  monoLight,
+  monoDark,
+  lavenderLight,
+  lavenderDark,
+  oceanLight,
+  oceanDark,
+  bubblegumLight,
+  bubblegumDark,
+} as const;
 export type ThemeName = keyof typeof themes;

--- a/packages/unistiyles/theme/themes/lavender.ts
+++ b/packages/unistiyles/theme/themes/lavender.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const lavenderLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(280.0000 33.3333% 96.4706%)",
+    foreground: "hsl(216.9231 19.1176% 26.6667%)",
+    primary: "hsl(255.1351 91.7355% 76.2745%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(267.5676 90.2439% 91.9608%)",
+    secondaryForeground: "hsl(215 13.7931% 34.1176%)",
+    muted: "hsl(268.6957 100.0000% 95.4902%)",
+    mutedForeground: "hsl(220 8.9362% 46.0784%)",
+    accent: "hsl(292.5000 44.4444% 92.9412%)",
+    destructive: "hsl(0 93.5484% 81.7647%)",
+    destructiveForeground: "hsl(0 0% 100%)",
+    border: "hsl(267.5676 90.2439% 91.9608%)",
+    card: "hsl(0 0% 100%)",
+    input: "hsl(267.5676 90.2439% 91.9608%)",
+    inputSurface: "hsl(267.5676 90.2439% 91.9608%)",
+  },
+};
+
+export const lavenderDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(24 9.8039% 10%)",
+    foreground: "hsl(226.4516 100% 93.9216%)",
+    primary: "hsl(255.9036 95.4023% 82.9412%)",
+    primaryForeground: "hsl(24 9.8039% 10%)",
+    secondary: "hsl(272.5000 19.3548% 24.3137%)",
+    secondaryForeground: "hsl(216.0000 12.1951% 83.9216%)",
+    muted: "hsl(270 17.7778% 17.6471%)",
+    mutedForeground: "hsl(217.8947 10.6145% 64.9020%)",
+    accent: "hsl(266.8966 19.2053% 29.6078%)",
+    destructive: "hsl(0 93.5484% 81.7647%)",
+    destructiveForeground: "hsl(24 9.8039% 10%)",
+    border: "hsl(272.5000 19.3548% 24.3137%)",
+    card: "hsl(270 17.7778% 17.6471%)",
+    input: "hsl(272.5000 19.3548% 24.3137%)",
+    inputSurface: "hsl(272.5000 19.3548% 24.3137%)",
+  },
+};

--- a/packages/unistiyles/theme/themes/mono.ts
+++ b/packages/unistiyles/theme/themes/mono.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const monoLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 100%)",
+    foreground: "hsl(0 0% 3.9216%)",
+    primary: "hsl(0 0% 45.0980%)",
+    primaryForeground: "hsl(0 0% 98.0392%)",
+    secondary: "hsl(0 0% 96.0784%)",
+    secondaryForeground: "hsl(0 0% 9.0196%)",
+    muted: "hsl(0 0% 96.0784%)",
+    mutedForeground: "hsl(0 0% 44.3137%)",
+    accent: "hsl(0 0% 96.0784%)",
+    destructive: "hsl(357.1429 100% 45.2941%)",
+    destructiveForeground: "hsl(0 0% 96.0784%)",
+    border: "hsl(0 0% 89.8039%)",
+    card: "hsl(0 0% 100%)",
+    input: "hsl(0 0% 89.8039%)",
+    inputSurface: "hsl(0 0% 96.0784%)",
+  },
+};
+
+export const monoDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 3.9216%)",
+    foreground: "hsl(0 0% 98.0392%)",
+    primary: "hsl(0 0% 45.0980%)",
+    primaryForeground: "hsl(0 0% 98.0392%)",
+    secondary: "hsl(0 0% 14.9020%)",
+    secondaryForeground: "hsl(0 0% 98.0392%)",
+    muted: "hsl(0 0% 14.9020%)",
+    mutedForeground: "hsl(0 0% 63.1373%)",
+    accent: "hsl(0 0% 25.0980%)",
+    destructive: "hsl(358.8387 100% 69.6078%)",
+    destructiveForeground: "hsl(0 0% 14.9020%)",
+    border: "hsl(0 0% 21.9608%)",
+    card: "hsl(0 0% 9.8039%)",
+    input: "hsl(0 0% 32.1569%)",
+    inputSurface: "hsl(0 0% 14.9020%)",
+  },
+};

--- a/packages/unistiyles/theme/themes/ocean.ts
+++ b/packages/unistiyles/theme/themes/ocean.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const oceanLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 100%)",
+    foreground: "hsl(210 25% 7.8431%)",
+    primary: "hsl(203.8863 88.2845% 53.1373%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(210 25% 7.8431%)",
+    secondaryForeground: "hsl(0 0% 100%)",
+    muted: "hsl(240 1.9608% 90%)",
+    mutedForeground: "hsl(210 25% 7.8431%)",
+    accent: "hsl(211.5789 51.3514% 92.7451%)",
+    destructive: "hsl(356.3033 90.5579% 54.3137%)",
+    destructiveForeground: "hsl(0 0% 100%)",
+    border: "hsl(201.4286 30.4348% 90.9804%)",
+    card: "hsl(180 6.6667% 97.0588%)",
+    input: "hsl(200 23.0769% 97.4510%)",
+    inputSurface: "hsl(240 1.9608% 90%)",
+  },
+};
+
+export const oceanDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 0%)",
+    foreground: "hsl(200 6.6667% 91.1765%)",
+    primary: "hsl(203.7736 87.6033% 52.5490%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(195.0000 15.3846% 94.9020%)",
+    secondaryForeground: "hsl(210 25% 7.8431%)",
+    muted: "hsl(0 0% 9.4118%)",
+    mutedForeground: "hsl(210 3.3898% 46.2745%)",
+    accent: "hsl(205.7143 70% 7.8431%)",
+    destructive: "hsl(356.3033 90.5579% 54.3137%)",
+    destructiveForeground: "hsl(0 0% 100%)",
+    border: "hsl(210 5.2632% 14.9020%)",
+    card: "hsl(228 9.8039% 10%)",
+    input: "hsl(207.6923 27.6596% 18.4314%)",
+    inputSurface: "hsl(0 0% 9.4118%)",
+  },
+};

--- a/packages/unistiyles/theme/themes/peach.ts
+++ b/packages/unistiyles/theme/themes/peach.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const peachLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(330 47.0588% 93.3333%)",
+    foreground: "hsl(0 0% 35.6863%)",
+    primary: "hsl(325.5814 57.8475% 56.2745%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(181.6901 43.5583% 68.0392%)",
+    secondaryForeground: "hsl(0 0% 20%)",
+    muted: "hsl(190.5263 58.7629% 80.9804%)",
+    mutedForeground: "hsl(0 0% 47.8431%)",
+    accent: "hsl(42.1429 91.3043% 81.9608%)",
+    destructive: "hsl(359.5652 92.0000% 70.5882%)",
+    destructiveForeground: "hsl(0 0% 100%)",
+    border: "hsl(325.5814 57.8475% 56.2745%)",
+    card: "hsl(41.5385 92.8571% 89.0196%)",
+    input: "hsl(0 0% 89.4118%)",
+    inputSurface: "hsl(181.6901 43.5583% 68.0392%)",
+  },
+};
+
+export const peachDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(201.4286 43.7500% 12.5490%)",
+    foreground: "hsl(333.7500 40.0000% 92.1569%)",
+    primary: "hsl(42.1429 91.3043% 81.9608%)",
+    primaryForeground: "hsl(201.4286 43.7500% 12.5490%)",
+    secondary: "hsl(346.3636 55.0000% 76.4706%)",
+    secondaryForeground: "hsl(201.4286 43.7500% 12.5490%)",
+    muted: "hsl(214.2857 8.8608% 15.4902%)",
+    mutedForeground: "hsl(346.3636 55.0000% 76.4706%)",
+    accent: "hsl(338.4000 39.6825% 62.9412%)",
+    destructive: "hsl(328.4211 70.3704% 62.9412%)",
+    destructiveForeground: "hsl(201.4286 43.7500% 12.5490%)",
+    border: "hsl(206.1538 28.0576% 27.2549%)",
+    card: "hsl(201.4286 33.3333% 16.4706%)",
+    input: "hsl(200.6897 31.1828% 18.2353%)",
+    inputSurface: "hsl(346.3636 55.0000% 76.4706%)",
+  },
+};

--- a/packages/unistiyles/theme/themes/retro.ts
+++ b/packages/unistiyles/theme/themes/retro.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const retroLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 80%)",
+    foreground: "hsl(0 0% 12.1569%)",
+    primary: "hsl(0 73.4597% 41.3725%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(82 38.9610% 30.1961%)",
+    secondaryForeground: "hsl(0 0% 100%)",
+    muted: "hsl(0 0% 72.1569%)",
+    mutedForeground: "hsl(0 0% 29.0196%)",
+    accent: "hsl(207.2727 44% 49.0196%)",
+    destructive: "hsl(26.1176 100% 50%)",
+    destructiveForeground: "hsl(0 0% 0%)",
+    border: "hsl(0 0% 31.3725%)",
+    card: "hsl(0 0% 69.0196%)",
+    input: "hsl(0 0% 31.3725%)",
+    inputSurface: "hsl(0 0% 72.1569%)",
+  },
+};
+
+export const retroDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "hsl(0 0% 10.1961%)",
+    foreground: "hsl(0 0% 87.8431%)",
+    primary: "hsl(1.3636 77.1930% 55.2941%)",
+    primaryForeground: "hsl(0 0% 100%)",
+    secondary: "hsl(92.0388 47.9070% 42.1569%)",
+    secondaryForeground: "hsl(0 0% 0%)",
+    muted: "hsl(0 0% 14.5098%)",
+    mutedForeground: "hsl(0 0% 62.7451%)",
+    accent: "hsl(206.7123 89.0244% 67.8431%)",
+    destructive: "hsl(37.6471 100% 50%)",
+    destructiveForeground: "hsl(0 0% 0%)",
+    border: "hsl(0 0% 29.0196%)",
+    card: "hsl(0 0% 16.4706%)",
+    input: "hsl(0 0% 29.0196%)",
+    inputSurface: "hsl(0 0% 14.5098%)",
+  },
+};


### PR DESCRIPTION
## Summary
- add a set of colorful themes for both implementations
- export the new themes from theme indexes

## Testing
- `npx tsc -p packages/unistiyles/tsconfig.json`
- `npx tsc -p packages/rn/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_685ad4bfc7c48320808ee7cd9bde3d94