### PR TITLE
Add new preset themes

### DIFF
--- a/packages/rn/theme/themes/amethyst-haze-dark.ts
+++ b/packages/rn/theme/themes/amethyst-haze-dark.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const amethystHazeDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#1a1823",
+    foreground: "#e0ddef",
+    primary: "#a995c9",
+    primaryForeground: "#1a1823",
+    secondary: "#5a5370",
+    secondaryForeground: "#e0ddef",
+    muted: "#242031",
+    mutedForeground: "#a09aad",
+    accent: "#372e3f",
+    destructive: "#e57373",
+    destructiveForeground: "#1a1823",
+    border: "#302c40",
+    card: "#232030",
+    input: "#2a273a",
+    inputSurface: "#2a273a",
+  },
+};

--- a/packages/rn/theme/themes/amethyst-haze-light.ts
+++ b/packages/rn/theme/themes/amethyst-haze-light.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const amethystHazeLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#f8f7fa",
+    foreground: "#3d3c4f",
+    primary: "#8a79ab",
+    primaryForeground: "#f8f7fa",
+    secondary: "#dfd9ec",
+    secondaryForeground: "#3d3c4f",
+    muted: "#dcd9e3",
+    mutedForeground: "#6b6880",
+    accent: "#e6a5b8",
+    destructive: "#d95c5c",
+    destructiveForeground: "#f8f7fa",
+    border: "#cec9d9",
+    card: "#ffffff",
+    input: "#eae7f0",
+    inputSurface: "#eae7f0",
+  },
+};

--- a/packages/rn/theme/themes/index.ts
+++ b/packages/rn/theme/themes/index.ts
@@ -14,6 +14,16 @@ import { oceanLight } from "./ocean-light";
 import { oceanDark } from "./ocean-dark";
 import { bubblegumLight } from "./bubblegum-light";
 import { bubblegumDark } from "./bubblegum-dark";
+import { t3ChatLight } from "./t3-chat-light";
+import { t3ChatDark } from "./t3-chat-dark";
+import { twitterLight } from "./twitter-light";
+import { twitterDark } from "./twitter-dark";
+import { mochaMousseLight } from "./mocha-mousse-light";
+import { mochaMousseDark } from "./mocha-mousse-dark";
+import { amethystHazeLight } from "./amethyst-haze-light";
+import { amethystHazeDark } from "./amethyst-haze-dark";
+import { supabaseLight } from "./supabase-light";
+import { supabaseDark } from "./supabase-dark";
 
 export const themes = {
   light,
@@ -32,5 +42,15 @@ export const themes = {
   oceanDark,
   bubblegumLight,
   bubblegumDark,
+  t3ChatLight,
+  t3ChatDark,
+  twitterLight,
+  twitterDark,
+  mochaMousseLight,
+  mochaMousseDark,
+  amethystHazeLight,
+  amethystHazeDark,
+  supabaseLight,
+  supabaseDark,
 };
 export type ThemeName = keyof typeof themes;

--- a/packages/rn/theme/themes/mocha-mousse-dark.ts
+++ b/packages/rn/theme/themes/mocha-mousse-dark.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const mochaMousseDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#2d2521",
+    foreground: "#F1F0E5",
+    primary: "#C39E88",
+    primaryForeground: "#2d2521",
+    secondary: "#8A655A",
+    secondaryForeground: "#F1F0E5",
+    muted: "#56453F",
+    mutedForeground: "#c5aa9b",
+    accent: "#BAAB92",
+    destructive: "#E57373",
+    destructiveForeground: "#2d2521",
+    border: "#56453F",
+    card: "#3c332e",
+    input: "#56453F",
+    inputSurface: "#56453F",
+  },
+};

--- a/packages/rn/theme/themes/mocha-mousse-light.ts
+++ b/packages/rn/theme/themes/mocha-mousse-light.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const mochaMousseLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#F1F0E5",
+    foreground: "#56453F",
+    primary: "#A37764",
+    primaryForeground: "#FFFFFF",
+    secondary: "#BAAB92",
+    secondaryForeground: "#ffffff",
+    muted: "#E4C7B8",
+    mutedForeground: "#8A655A",
+    accent: "#E4C7B8",
+    destructive: "#1f1a17",
+    destructiveForeground: "#FFFFFF",
+    border: "#BAAB92",
+    card: "#F1F0E5",
+    input: "#BAAB92",
+    inputSurface: "#BAAB92",
+  },
+};

--- a/packages/rn/theme/themes/supabase-dark.ts
+++ b/packages/rn/theme/themes/supabase-dark.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const supabaseDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#121212",
+    foreground: "#e2e8f0",
+    primary: "#006239",
+    primaryForeground: "#dde8e3",
+    secondary: "#242424",
+    secondaryForeground: "#fafafa",
+    muted: "#1f1f1f",
+    mutedForeground: "#a2a2a2",
+    accent: "#313131",
+    destructive: "#541c15",
+    destructiveForeground: "#ede9e8",
+    border: "#292929",
+    card: "#171717",
+    input: "#242424",
+    inputSurface: "#242424",
+  },
+};

--- a/packages/rn/theme/themes/supabase-light.ts
+++ b/packages/rn/theme/themes/supabase-light.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const supabaseLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#fcfcfc",
+    foreground: "#171717",
+    primary: "#72e3ad",
+    primaryForeground: "#1e2723",
+    secondary: "#fdfdfd",
+    secondaryForeground: "#171717",
+    muted: "#ededed",
+    mutedForeground: "#202020",
+    accent: "#ededed",
+    destructive: "#ca3214",
+    destructiveForeground: "#fffcfc",
+    border: "#dfdfdf",
+    card: "#fcfcfc",
+    input: "#f6f6f6",
+    inputSurface: "#f6f6f6",
+  },
+};

--- a/packages/rn/theme/themes/t3-chat-dark.ts
+++ b/packages/rn/theme/themes/t3-chat-dark.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const t3ChatDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#221d27",
+    foreground: "#d2c4de",
+    primary: "#a3004c",
+    primaryForeground: "#efc0d8",
+    secondary: "#362d3d",
+    secondaryForeground: "#d4c7e1",
+    muted: "#28222d",
+    mutedForeground: "#c2b6cf",
+    accent: "#463753",
+    destructive: "#301015",
+    destructiveForeground: "#ffffff",
+    border: "#3b3237",
+    card: "#2c2632",
+    input: "#3e343c",
+    inputSurface: "#3e343c",
+  },
+};

--- a/packages/rn/theme/themes/t3-chat-light.ts
+++ b/packages/rn/theme/themes/t3-chat-light.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const t3ChatLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#faf5fa",
+    foreground: "#501854",
+    primary: "#a84370",
+    primaryForeground: "#ffffff",
+    secondary: "#f1c4e6",
+    secondaryForeground: "#77347c",
+    muted: "#f6e5f3",
+    mutedForeground: "#834588",
+    accent: "#f1c4e6",
+    destructive: "#ab4347",
+    destructiveForeground: "#ffffff",
+    border: "#efbdeb",
+    card: "#faf5fa",
+    input: "#e7c1dc",
+    inputSurface: "#e7c1dc",
+  },
+};

--- a/packages/rn/theme/themes/twitter-dark.ts
+++ b/packages/rn/theme/themes/twitter-dark.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const twitterDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#000000",
+    foreground: "#e7e9ea",
+    primary: "#1c9cf0",
+    primaryForeground: "#ffffff",
+    secondary: "#f0f3f4",
+    secondaryForeground: "#0f1419",
+    muted: "#181818",
+    mutedForeground: "#72767a",
+    accent: "#061622",
+    destructive: "#f4212e",
+    destructiveForeground: "#ffffff",
+    border: "#242628",
+    card: "#17181c",
+    input: "#22303c",
+    inputSurface: "#22303c",
+  },
+};

--- a/packages/rn/theme/themes/twitter-light.ts
+++ b/packages/rn/theme/themes/twitter-light.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const twitterLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#ffffff",
+    foreground: "#0f1419",
+    primary: "#1e9df1",
+    primaryForeground: "#ffffff",
+    secondary: "#0f1419",
+    secondaryForeground: "#ffffff",
+    muted: "#E5E5E6",
+    mutedForeground: "#0f1419",
+    accent: "#E3ECF6",
+    destructive: "#f4212e",
+    destructiveForeground: "#ffffff",
+    border: "#e1eaef",
+    card: "#f7f8f8",
+    input: "#f7f9fa",
+    inputSurface: "#f7f9fa",
+  },
+};

--- a/packages/unistyles/theme/themes/amethyst-haze-dark.ts
+++ b/packages/unistyles/theme/themes/amethyst-haze-dark.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const amethystHazeDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#1a1823",
+    foreground: "#e0ddef",
+    primary: "#a995c9",
+    primaryForeground: "#1a1823",
+    secondary: "#5a5370",
+    secondaryForeground: "#e0ddef",
+    muted: "#242031",
+    mutedForeground: "#a09aad",
+    accent: "#372e3f",
+    destructive: "#e57373",
+    destructiveForeground: "#1a1823",
+    border: "#302c40",
+    card: "#232030",
+    input: "#2a273a",
+    inputSurface: "#2a273a",
+  },
+};

--- a/packages/unistyles/theme/themes/amethyst-haze-light.ts
+++ b/packages/unistyles/theme/themes/amethyst-haze-light.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const amethystHazeLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#f8f7fa",
+    foreground: "#3d3c4f",
+    primary: "#8a79ab",
+    primaryForeground: "#f8f7fa",
+    secondary: "#dfd9ec",
+    secondaryForeground: "#3d3c4f",
+    muted: "#dcd9e3",
+    mutedForeground: "#6b6880",
+    accent: "#e6a5b8",
+    destructive: "#d95c5c",
+    destructiveForeground: "#f8f7fa",
+    border: "#cec9d9",
+    card: "#ffffff",
+    input: "#eae7f0",
+    inputSurface: "#eae7f0",
+  },
+};

--- a/packages/unistyles/theme/themes/index.ts
+++ b/packages/unistyles/theme/themes/index.ts
@@ -15,6 +15,16 @@ import { oceanLight } from "./ocean-light";
 import { oceanDark } from "./ocean-dark";
 import { bubblegumLight } from "./bubblegum-light";
 import { bubblegumDark } from "./bubblegum-dark";
+import { t3ChatLight } from "./t3-chat-light";
+import { t3ChatDark } from "./t3-chat-dark";
+import { twitterLight } from "./twitter-light";
+import { twitterDark } from "./twitter-dark";
+import { mochaMousseLight } from "./mocha-mousse-light";
+import { mochaMousseDark } from "./mocha-mousse-dark";
+import { amethystHazeLight } from "./amethyst-haze-light";
+import { amethystHazeDark } from "./amethyst-haze-dark";
+import { supabaseLight } from "./supabase-light";
+import { supabaseDark } from "./supabase-dark";
 export {
   light,
   dark,
@@ -32,6 +42,16 @@ export {
   oceanDark,
   bubblegumLight,
   bubblegumDark,
+  t3ChatLight,
+  t3ChatDark,
+  twitterLight,
+  twitterDark,
+  mochaMousseLight,
+  mochaMousseDark,
+  amethystHazeLight,
+  amethystHazeDark,
+  supabaseLight,
+  supabaseDark,
 };
 
 export const themes = {
@@ -51,5 +71,15 @@ export const themes = {
   oceanDark,
   bubblegumLight,
   bubblegumDark,
+  t3ChatLight,
+  t3ChatDark,
+  twitterLight,
+  twitterDark,
+  mochaMousseLight,
+  mochaMousseDark,
+  amethystHazeLight,
+  amethystHazeDark,
+  supabaseLight,
+  supabaseDark,
 } as const;
 export type ThemeName = keyof typeof themes;

--- a/packages/unistyles/theme/themes/mocha-mousse-dark.ts
+++ b/packages/unistyles/theme/themes/mocha-mousse-dark.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const mochaMousseDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#2d2521",
+    foreground: "#F1F0E5",
+    primary: "#C39E88",
+    primaryForeground: "#2d2521",
+    secondary: "#8A655A",
+    secondaryForeground: "#F1F0E5",
+    muted: "#56453F",
+    mutedForeground: "#c5aa9b",
+    accent: "#BAAB92",
+    destructive: "#E57373",
+    destructiveForeground: "#2d2521",
+    border: "#56453F",
+    card: "#3c332e",
+    input: "#56453F",
+    inputSurface: "#56453F",
+  },
+};

--- a/packages/unistyles/theme/themes/mocha-mousse-light.ts
+++ b/packages/unistyles/theme/themes/mocha-mousse-light.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const mochaMousseLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#F1F0E5",
+    foreground: "#56453F",
+    primary: "#A37764",
+    primaryForeground: "#FFFFFF",
+    secondary: "#BAAB92",
+    secondaryForeground: "#ffffff",
+    muted: "#E4C7B8",
+    mutedForeground: "#8A655A",
+    accent: "#E4C7B8",
+    destructive: "#1f1a17",
+    destructiveForeground: "#FFFFFF",
+    border: "#BAAB92",
+    card: "#F1F0E5",
+    input: "#BAAB92",
+    inputSurface: "#BAAB92",
+  },
+};

--- a/packages/unistyles/theme/themes/supabase-dark.ts
+++ b/packages/unistyles/theme/themes/supabase-dark.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const supabaseDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#121212",
+    foreground: "#e2e8f0",
+    primary: "#006239",
+    primaryForeground: "#dde8e3",
+    secondary: "#242424",
+    secondaryForeground: "#fafafa",
+    muted: "#1f1f1f",
+    mutedForeground: "#a2a2a2",
+    accent: "#313131",
+    destructive: "#541c15",
+    destructiveForeground: "#ede9e8",
+    border: "#292929",
+    card: "#171717",
+    input: "#242424",
+    inputSurface: "#242424",
+  },
+};

--- a/packages/unistyles/theme/themes/supabase-light.ts
+++ b/packages/unistyles/theme/themes/supabase-light.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const supabaseLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#fcfcfc",
+    foreground: "#171717",
+    primary: "#72e3ad",
+    primaryForeground: "#1e2723",
+    secondary: "#fdfdfd",
+    secondaryForeground: "#171717",
+    muted: "#ededed",
+    mutedForeground: "#202020",
+    accent: "#ededed",
+    destructive: "#ca3214",
+    destructiveForeground: "#fffcfc",
+    border: "#dfdfdf",
+    card: "#fcfcfc",
+    input: "#f6f6f6",
+    inputSurface: "#f6f6f6",
+  },
+};

--- a/packages/unistyles/theme/themes/t3-chat-dark.ts
+++ b/packages/unistyles/theme/themes/t3-chat-dark.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const t3ChatDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#221d27",
+    foreground: "#d2c4de",
+    primary: "#a3004c",
+    primaryForeground: "#efc0d8",
+    secondary: "#362d3d",
+    secondaryForeground: "#d4c7e1",
+    muted: "#28222d",
+    mutedForeground: "#c2b6cf",
+    accent: "#463753",
+    destructive: "#301015",
+    destructiveForeground: "#ffffff",
+    border: "#3b3237",
+    card: "#2c2632",
+    input: "#3e343c",
+    inputSurface: "#3e343c",
+  },
+};

--- a/packages/unistyles/theme/themes/t3-chat-light.ts
+++ b/packages/unistyles/theme/themes/t3-chat-light.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const t3ChatLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#faf5fa",
+    foreground: "#501854",
+    primary: "#a84370",
+    primaryForeground: "#ffffff",
+    secondary: "#f1c4e6",
+    secondaryForeground: "#77347c",
+    muted: "#f6e5f3",
+    mutedForeground: "#834588",
+    accent: "#f1c4e6",
+    destructive: "#ab4347",
+    destructiveForeground: "#ffffff",
+    border: "#efbdeb",
+    card: "#faf5fa",
+    input: "#e7c1dc",
+    inputSurface: "#e7c1dc",
+  },
+};

--- a/packages/unistyles/theme/themes/twitter-dark.ts
+++ b/packages/unistyles/theme/themes/twitter-dark.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const twitterDark: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#000000",
+    foreground: "#e7e9ea",
+    primary: "#1c9cf0",
+    primaryForeground: "#ffffff",
+    secondary: "#f0f3f4",
+    secondaryForeground: "#0f1419",
+    muted: "#181818",
+    mutedForeground: "#72767a",
+    accent: "#061622",
+    destructive: "#f4212e",
+    destructiveForeground: "#ffffff",
+    border: "#242628",
+    card: "#17181c",
+    input: "#22303c",
+    inputSurface: "#22303c",
+  },
+};

--- a/packages/unistyles/theme/themes/twitter-light.ts
+++ b/packages/unistyles/theme/themes/twitter-light.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "../theme";
+import { fonts, shadows, sizes, radii } from "./common";
+
+export const twitterLight: Theme = {
+  fonts,
+  shadows,
+  sizes,
+  radii,
+  colors: {
+    background: "#ffffff",
+    foreground: "#0f1419",
+    primary: "#1e9df1",
+    primaryForeground: "#ffffff",
+    secondary: "#0f1419",
+    secondaryForeground: "#ffffff",
+    muted: "#E5E5E6",
+    mutedForeground: "#0f1419",
+    accent: "#E3ECF6",
+    destructive: "#f4212e",
+    destructiveForeground: "#ffffff",
+    border: "#e1eaef",
+    card: "#f7f8f8",
+    input: "#f7f9fa",
+    inputSurface: "#f7f9fa",
+  },
+};


### PR DESCRIPTION
## Summary
- add several additional theme presets for both Unistyles and RN
- export new theme presets in theme indexes

## Testing
- `npx tsc -p packages/unistyles/tsconfig.json`
- `npx tsc -p packages/rn/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_685af3cc1ebc8320ba520b4c9103ace1