### PR TITLE
Fix npm version bump in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,9 @@ jobs:
       - run: git config user.name "github-actions"
       - run: git config user.email "github-actions@github.com"
 
-      - run: cd cli && npm version patch --no-git-tag-version
+      # Bump CLI version within the workspace. Running from the workspace root
+      # avoids npm failing to resolve workspace protocol dependencies.
+      - run: npm --workspace cli version patch --no-git-tag-version
 
       - run: git add cli/package.json && git commit -m "bump version [skip ci]" && git push
 


### PR DESCRIPTION
## Summary
- fix npm version command in release workflow

## Testing
- `npx tsc -p packages/unistyles/tsconfig.json`
- `npx tsc -p packages/rn/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_685e9e958f3483208d9f3b7ba6f21d0b