### PR TITLE
Add Tabs component

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Over 18 production-ready components with smart dependency resolution:
 | **radio** | Radio group | `icon` | None |
 | **slot** | Component composition | None | None |
 | **spinner** | Loading spinner | None | `react-native-reanimated` |
+| **tabs** | Tabbed navigation | `text` | `react-native-reanimated` |
 
 > **Smart Dependencies**: The CLI automatically installs required components and warns about external dependencies.
 

--- a/apps/demo/app/components/Tabs.tsx
+++ b/apps/demo/app/components/Tabs.tsx
@@ -1,0 +1,33 @@
+import { ScrollView } from "react-native";
+import { Tabs, Text, Surface } from "@leshi/ui-rn";
+
+export default function TabsScreen() {
+  return (
+    <ScrollView contentContainerStyle={{ padding: 16 }}>
+      <Text weight="bold" size="xl" style={{ marginBottom: 4 }}>
+        Tabs
+      </Text>
+      <Text style={{ marginBottom: 12 }}>
+        Simple tabbed navigation with animated indicator.
+      </Text>
+      <Surface style={{ padding: 16 }}>
+        <Tabs.Root defaultValue="tab1">
+          <Tabs.List>
+            <Tabs.Trigger value="tab1">Tab One</Tabs.Trigger>
+            <Tabs.Trigger value="tab2">Tab Two</Tabs.Trigger>
+            <Tabs.Trigger value="tab3">Tab Three</Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Content value="tab1">
+            <Text>Content for the first tab.</Text>
+          </Tabs.Content>
+          <Tabs.Content value="tab2">
+            <Text>Content for the second tab.</Text>
+          </Tabs.Content>
+          <Tabs.Content value="tab3">
+            <Text>Content for the third tab.</Text>
+          </Tabs.Content>
+        </Tabs.Root>
+      </Surface>
+    </ScrollView>
+  );
+}

--- a/apps/demo/app/index.tsx
+++ b/apps/demo/app/index.tsx
@@ -17,6 +17,7 @@ const componentScreens = [
   { name: "Spinner", href: "/components/Spinner" },
   { name: "Surface", href: "/components/Surface" },
   { name: "Switch", href: "/components/Switch" },
+  { name: "Tabs", href: "/components/Tabs" },
   { name: "Text", href: "/components/Text" },
   { name: "TextArea", href: "/components/TextArea" },
   { name: "TextInput", href: "/components/TextInput" },

--- a/component-notes.json
+++ b/component-notes.json
@@ -130,7 +130,16 @@
     "setup": [
       "Install external dependency: bun add react-native-reanimated"
     ],
-    "example": "import { Switch } from './components/ui/switch';\n\n<Switch\n  checked={enabled}\n  onCheckedChange={setEnabled}\n  label=\"Enable notifications\"\n/>"
+    "example": "import { Switch } from './components/ui/switch';\n\n<Switch\n  checked={enabled}\n  onCheckedChange={setEnabled}\n  label=\\"Enable notifications\\"\n/>"
+  },
+  "tabs": {
+    "dependencies": ["text"],
+    "externalDeps": ["react-native-reanimated"],
+    "setup": [
+      "Install external dependency: bun add react-native-reanimated",
+      "Install dependency: leshi-ui add component text"
+    ],
+    "example": "import { Tabs } from './components/ui/tabs';\n\n<Tabs.Root defaultValue=\\"home\\">\n  <Tabs.List>\n    <Tabs.Trigger value=\\"home\\">Home</Tabs.Trigger>\n    <Tabs.Trigger value=\\"settings\\">Settings</Tabs.Trigger>\n  </Tabs.List>\n  <Tabs.Content value=\\"home\\">Home content</Tabs.Content>\n  <Tabs.Content value=\\"settings\\">Settings content</Tabs.Content>\n</Tabs.Root>"
   },
   "slot": {
     "dependencies": [],

--- a/docs/components.md
+++ b/docs/components.md
@@ -649,6 +649,37 @@ import { Spinner } from './components/ui/spinner';
 
 ---
 
+### **Tabs**
+```bash
+leshi-ui add component tabs
+```
+
+Tabbed navigation with animated indicator.
+
+**Dependencies:** `text`
+
+**External Dependencies:** `react-native-reanimated`
+
+**Usage:**
+```typescript
+import { Tabs } from './components/ui/tabs';
+
+<Tabs.Root defaultValue="tab1">
+  <Tabs.List>
+    <Tabs.Trigger value="tab1">Tab 1</Tabs.Trigger>
+    <Tabs.Trigger value="tab2">Tab 2</Tabs.Trigger>
+  </Tabs.List>
+  <Tabs.Content value="tab1">
+    <Text>First tab content</Text>
+  </Tabs.Content>
+  <Tabs.Content value="tab2">
+    <Text>Second tab content</Text>
+  </Tabs.Content>
+</Tabs.Root>
+```
+
+---
+
 ### **Slot**
 ```bash
 leshi-ui add component slot

--- a/packages/rn/components/ui/tabs.tsx
+++ b/packages/rn/components/ui/tabs.tsx
@@ -1,0 +1,185 @@
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import {
+  View,
+  Pressable,
+  type ViewProps,
+  type PressableProps,
+  type LayoutChangeEvent,
+  StyleSheet,
+} from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { useTheme } from '../../styles/theme';
+import type { Theme } from '../../styles/theme';
+import { Text } from './text';
+
+interface TabsContextValue {
+  value: string;
+  setValue: (val: string) => void;
+  register: (val: string, layout: { x: number; width: number }) => void;
+  indicatorX: Animated.SharedValue<number>;
+  indicatorW: Animated.SharedValue<number>;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+const useTabs = () => {
+  const ctx = useContext(TabsContext);
+  if (!ctx) throw new Error('Tabs components must be inside <Tabs.Root>');
+  return ctx;
+};
+
+export interface TabsRootProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  children: React.ReactNode;
+}
+
+function TabsRoot({ value: controlled, defaultValue, onValueChange, children }: TabsRootProps) {
+  const [uncontrolled, setUncontrolled] = useState(defaultValue ?? '');
+  const value = controlled ?? uncontrolled;
+
+  const indicatorX = useSharedValue(0);
+  const indicatorW = useSharedValue(0);
+  const layouts = useRef<Record<string, { x: number; width: number }>>({});
+
+  const setValue = useCallback(
+    (v: string) => {
+      if (controlled === undefined) setUncontrolled(v);
+      onValueChange?.(v);
+      const layout = layouts.current[v];
+      if (layout) {
+        indicatorX.value = withTiming(layout.x, { duration: 200 });
+        indicatorW.value = withTiming(layout.width, { duration: 200 });
+      }
+    },
+    [controlled, onValueChange, indicatorX, indicatorW],
+  );
+
+  const register = useCallback(
+    (val: string, layout: { x: number; width: number }) => {
+      layouts.current[val] = layout;
+      if (val === value) {
+        indicatorX.value = layout.x;
+        indicatorW.value = layout.width;
+      }
+    },
+    [value, indicatorX, indicatorW],
+  );
+
+  const context = useMemo(
+    () => ({ value, setValue, register, indicatorX, indicatorW }),
+    [value, setValue, register, indicatorX, indicatorW],
+  );
+
+  return <TabsContext.Provider value={context}>{children}</TabsContext.Provider>;
+}
+
+export interface TabsListProps extends ViewProps {
+  children: React.ReactNode;
+}
+
+function TabsList({ children, style, ...rest }: TabsListProps) {
+  const theme = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { indicatorX, indicatorW } = useTabs();
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: indicatorX.value }],
+    width: indicatorW.value,
+  }));
+
+  return (
+    <View style={[styles.list, style]} {...rest}>
+      {children}
+      <Animated.View style={[styles.indicator, animatedStyle]} />
+    </View>
+  );
+}
+
+export interface TabsTriggerProps extends PressableProps {
+  value: string;
+  children: React.ReactNode;
+}
+
+function TabsTrigger({ value, children, onPress, onLayout, style, ...rest }: TabsTriggerProps) {
+  const { value: active, setValue, register } = useTabs();
+  const theme = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const isActive = active === value;
+
+  const handleLayout = useCallback(
+    (e: LayoutChangeEvent) => {
+      onLayout?.(e);
+      register(value, {
+        x: e.nativeEvent.layout.x,
+        width: e.nativeEvent.layout.width,
+      });
+    },
+    [value, onLayout, register],
+  );
+
+  const handlePress = useCallback(
+    (e: any) => {
+      onPress?.(e);
+      if (!e.defaultPrevented) setValue(value);
+    },
+    [onPress, setValue, value],
+  );
+
+  return (
+    <Pressable
+      accessibilityRole='tab'
+      accessibilityState={{ selected: isActive }}
+      onLayout={handleLayout}
+      onPress={handlePress}
+      style={[styles.trigger, isActive && styles.triggerActive, style]}
+      {...rest}
+    >
+      <Text variant={isActive ? 'primary' : 'mutedForeground'} weight='medium'>
+        {children}
+      </Text>
+    </Pressable>
+  );
+}
+
+export interface TabsContentProps extends ViewProps {
+  value: string;
+  children: React.ReactNode;
+}
+
+function TabsContent({ value, children, style, ...rest }: TabsContentProps) {
+  const { value: active } = useTabs();
+  const theme = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  if (value !== active) return null;
+  return (
+    <View style={[styles.content, style]} {...rest}>
+      {children}
+    </View>
+  );
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    list: {
+      flexDirection: 'row',
+      position: 'relative',
+    },
+    indicator: {
+      position: 'absolute',
+      bottom: 0,
+      height: 2,
+      backgroundColor: theme.colors.primary,
+    },
+    trigger: {
+      paddingVertical: theme.sizes.padding(2),
+      paddingHorizontal: theme.sizes.padding(4),
+    },
+    triggerActive: {},
+    content: {
+      paddingTop: theme.sizes.padding(4),
+    },
+  });
+
+export const Tabs = { Root: TabsRoot, List: TabsList, Trigger: TabsTrigger, Content: TabsContent };

--- a/packages/rn/index.ts
+++ b/packages/rn/index.ts
@@ -13,6 +13,7 @@ export { Divider } from './components/ui/divider';
 export { Surface } from './components/ui/surface';
 export { Switch } from './components/ui/switch';
 export { RadioGroup, RadioGroupItem } from './components/ui/radio';
+export { Tabs } from './components/ui/tabs';
 export { Text } from './components/ui/text';
 export { TextArea } from './components/ui/text-area';
 export { TextInput } from './components/ui/text-input';

--- a/packages/unistyles/components/ui/tabs.tsx
+++ b/packages/unistyles/components/ui/tabs.tsx
@@ -1,0 +1,168 @@
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { View, Pressable, type ViewProps, type PressableProps, type LayoutChangeEvent } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { Text } from './text';
+
+interface TabsContextValue {
+  value: string;
+  setValue: (val: string) => void;
+  register: (val: string, layout: { x: number; width: number }) => void;
+  indicatorX: Animated.SharedValue<number>;
+  indicatorW: Animated.SharedValue<number>;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+const useTabs = () => {
+  const ctx = useContext(TabsContext);
+  if (!ctx) throw new Error('Tabs components must be inside <Tabs.Root>');
+  return ctx;
+};
+
+export interface TabsRootProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  children: React.ReactNode;
+}
+
+function TabsRoot({ value: controlled, defaultValue, onValueChange, children }: TabsRootProps) {
+  const [uncontrolled, setUncontrolled] = useState(defaultValue ?? '');
+  const value = controlled ?? uncontrolled;
+
+  const indicatorX = useSharedValue(0);
+  const indicatorW = useSharedValue(0);
+  const layouts = useRef<Record<string, { x: number; width: number }>>({});
+
+  const setValue = useCallback(
+    (v: string) => {
+      if (controlled === undefined) setUncontrolled(v);
+      onValueChange?.(v);
+      const layout = layouts.current[v];
+      if (layout) {
+        indicatorX.value = withTiming(layout.x, { duration: 200 });
+        indicatorW.value = withTiming(layout.width, { duration: 200 });
+      }
+    },
+    [controlled, onValueChange, indicatorX, indicatorW],
+  );
+
+  const register = useCallback(
+    (val: string, layout: { x: number; width: number }) => {
+      layouts.current[val] = layout;
+      if (val === value) {
+        indicatorX.value = layout.x;
+        indicatorW.value = layout.width;
+      }
+    },
+    [value, indicatorX, indicatorW],
+  );
+
+  const context = useMemo(
+    () => ({ value, setValue, register, indicatorX, indicatorW }),
+    [value, setValue, register, indicatorX, indicatorW],
+  );
+
+  return <TabsContext.Provider value={context}>{children}</TabsContext.Provider>;
+}
+
+export interface TabsListProps extends ViewProps {
+  children: React.ReactNode;
+}
+
+function TabsList({ children, style, ...rest }: TabsListProps) {
+  const { theme } = useUnistyles();
+  const { indicatorX, indicatorW } = useTabs();
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: indicatorX.value }],
+    width: indicatorW.value,
+  }));
+
+  return (
+    <View style={[styles.list, style]} {...rest}>
+      {children}
+      <Animated.View style={[styles.indicator(theme), animatedStyle]} />
+    </View>
+  );
+}
+
+export interface TabsTriggerProps extends PressableProps {
+  value: string;
+  children: React.ReactNode;
+}
+
+function TabsTrigger({ value, children, onPress, onLayout, style, ...rest }: TabsTriggerProps) {
+  const { value: active, setValue, register } = useTabs();
+  const isActive = active === value;
+
+  const handleLayout = useCallback(
+    (e: LayoutChangeEvent) => {
+      onLayout?.(e);
+      register(value, { x: e.nativeEvent.layout.x, width: e.nativeEvent.layout.width });
+    },
+    [value, onLayout, register],
+  );
+
+  const handlePress = useCallback(
+    (e: any) => {
+      onPress?.(e);
+      if (!e.defaultPrevented) setValue(value);
+    },
+    [onPress, setValue, value],
+  );
+
+  return (
+    <Pressable
+      accessibilityRole='tab'
+      accessibilityState={{ selected: isActive }}
+      onLayout={handleLayout}
+      onPress={handlePress}
+      style={[styles.trigger, isActive && styles.triggerActive, style]}
+      {...rest}
+    >
+      <Text variant={isActive ? 'primary' : 'mutedForeground'} weight='medium'>
+        {children}
+      </Text>
+    </Pressable>
+  );
+}
+
+export interface TabsContentProps extends ViewProps {
+  value: string;
+  children: React.ReactNode;
+}
+
+function TabsContent({ value, children, style, ...rest }: TabsContentProps) {
+  const { value: active } = useTabs();
+  if (value !== active) return null;
+  return (
+    <View style={[styles.content, style]} {...rest}>
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  list: {
+    flexDirection: 'row',
+    position: 'relative',
+  },
+  indicator: (t: typeof theme) => ({
+    position: 'absolute',
+    bottom: 0,
+    height: 2,
+    backgroundColor: t.colors.primary,
+  }),
+  trigger: {
+    paddingVertical: theme.sizes.padding(2),
+    paddingHorizontal: theme.sizes.padding(4),
+  },
+  triggerActive: {},
+  content: {
+    paddingTop: theme.sizes.padding(4),
+  },
+}));
+
+export const Tabs = { Root: TabsRoot, List: TabsList, Trigger: TabsTrigger, Content: TabsContent };

--- a/packages/unistyles/index.ts
+++ b/packages/unistyles/index.ts
@@ -18,6 +18,7 @@ export { Divider } from "./components/ui/divider";
 export { Surface } from "./components/ui/surface";
 export { Switch } from "./components/ui/switch";
 export { RadioGroup, RadioGroupItem } from "./components/ui/radio";
+export { Tabs } from "./components/ui/tabs";
 export { Text } from "./components/ui/text";
 export { TextArea } from "./components/ui/text-area";
 export { TextInput } from "./components/ui/text-input";


### PR DESCRIPTION
## Summary
- implement Tabs for both RN and Unistyles packages
- expose Tabs via package entry points
- document Tabs component and include in README list
- register Tabs in component registry
- add Tabs demo screen and navigation entry

## Testing
- `npx tsc --noEmit` in packages/rn
- `npx tsc --noEmit` in packages/unistyles
- `node dist/index.js --help` *(fails: Missing component registry from GitHub)*
- `node dist/index.js list component` *(fails: fetch failed)*
- `node dist/index.js guide component button` *(fails: fetch failed)*
- `node dist/index.js init --rn` *(cancelled prompt)*
- `node dist/index.js init --unistyles` *(cancelled prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6867e1739f448320bbb7e76af70bd392